### PR TITLE
bugfix - seg fault if `id` not first record

### DIFF
--- a/pychadwick/chadwick.py
+++ b/pychadwick/chadwick.py
@@ -103,14 +103,21 @@ class Chadwick:
         return func(gameiter_ptr)
 
     def games(self, file_path):
+        file_path = bytes(str(file_path), "utf8")
         cw_game_read = self.libchadwick.cw_game_read
         cw_game_read.restype = POINTER(CWGame)
         cw_game_read.argtypes = (ctypes.c_void_p,)
+        cw_file_find_first_game = self.libchadwick.cw_file_find_first_game
+        cw_file_find_first_game.restype = ctypes.c_int
+        cw_file_find_first_game.argtypes = (ctypes.c_void_p,)
+
         file_handle = self.fopen(file_path)
+
+        cw_file_find_first_game(file_handle)
         while not self.feof(file_handle):
             yield cw_game_read(file_handle)
 
-            # TODO: why is this here?
+            # TODO: why is this here? what's the exception?
             # except:
             #     self.fclose(file_handle)
             #     return

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@ black==19.10b0
 pytest==5.4.3
 pandas==1.0.4
 flake8==3.8.2
+requests==2.22.0

--- a/tests/pychadwick/test_pychadwick.py
+++ b/tests/pychadwick/test_pychadwick.py
@@ -3,13 +3,23 @@ from pychadwick.chadwick import Chadwick
 
 
 @pytest.fixture
-def lib_path():
-    return (
-        "/home/bdilday/.venvs/pychadwick/lib/python3.7/"
-        "site-packages/pychadwick-0.1.0-py3.7-linux-x86_64.egg/"
-        "pychadwick/build/cwevent/libcwevent.so"
-    )
+def event_path():
+    # return (
+    #    b"https://raw.githubusercontent.com/chadwickbureau/retrosheet/master/event/regular/1982OAK.EVA"
+    # )
+    #    return "/tmp/retrosheet-master/event/regular/1982OAK.EVA"
+    return "/tmp/retrosheet-master/event/regular/1991BAL.EVA"
 
 
-def test_chadwick(lib_path):
-    chadwick = Chadwick(lib_path)
+def test_chadwick():
+    _ = Chadwick()
+
+
+def test_load_games(event_path):
+    chadwick = Chadwick()
+    games = chadwick.games(event_path)
+
+    game = next(games)
+    game_it = chadwick.process_game(game)
+    record = next(game_it)
+    assert "GAME_ID" in record.keys()

--- a/tests/pychadwick/test_pychadwick.py
+++ b/tests/pychadwick/test_pychadwick.py
@@ -1,14 +1,15 @@
 import pytest
 from pychadwick.chadwick import Chadwick
-
+import tempfile
+import requests
 
 @pytest.fixture
 def event_path():
-    # return (
-    #    b"https://raw.githubusercontent.com/chadwickbureau/retrosheet/master/event/regular/1982OAK.EVA"
-    # )
-    #    return "/tmp/retrosheet-master/event/regular/1982OAK.EVA"
-    return "/tmp/retrosheet-master/event/regular/1991BAL.EVA"
+    url = "https://raw.githubusercontent.com/chadwickbureau/retrosheet/master/event/regular/1982OAK.EVA"
+    file_path = tempfile.gettempdir() + "/tmp.EVA"
+    with open(file_path, "w") as fh:
+        fh.write(requests.get(url).text)
+    return file_path
 
 
 def test_chadwick():

--- a/tests/pychadwick/test_pychadwick.py
+++ b/tests/pychadwick/test_pychadwick.py
@@ -3,9 +3,7 @@ from pychadwick.chadwick import Chadwick
 import tempfile
 import requests
 
-@pytest.fixture
-def event_path():
-    url = "https://raw.githubusercontent.com/chadwickbureau/retrosheet/master/event/regular/1982OAK.EVA"
+def get_event_path(url):
     file_path = tempfile.gettempdir() + "/tmp.EVA"
     with open(file_path, "w") as fh:
         fh.write(requests.get(url).text)
@@ -16,11 +14,16 @@ def test_chadwick():
     _ = Chadwick()
 
 
-def test_load_games(event_path):
+def test_load_games():
     chadwick = Chadwick()
-    games = chadwick.games(event_path)
 
-    game = next(games)
-    game_it = chadwick.process_game(game)
-    record = next(game_it)
-    assert "GAME_ID" in record.keys()
+
+    for team_event in ["1982OAK", "1991BAL"]:
+        event_path = get_event_path(
+        f"https://raw.githubusercontent.com/chadwickbureau/retrosheet/master/event/regular/{team_event}.EVA"
+        )
+        games = chadwick.games(event_path)
+        game = next(games)
+        game_it = chadwick.process_game(game)
+        record = next(game_it)
+        assert "GAME_ID" in record.keys()


### PR DESCRIPTION
This applies `cw_find_first_game` to a open event file. This avoids segmentation fault when the first line contains a `com`.