### PR TITLE
Fixes gameiter segfault

### DIFF
--- a/pychadwick/chadwick.py
+++ b/pychadwick/chadwick.py
@@ -1,7 +1,7 @@
 import ctypes
 from ctypes import (
     POINTER,
-c_char_p,
+    c_char_p,
     c_char,
     c_int,
     pointer,
@@ -165,26 +165,21 @@ class Chadwick:
         cw_league_init_read_file(league, file_name)
         return league
 
-    def read_rosters(self):
-        cwtools_read_rosters_inplace = self.libchadwick.cwtools_read_rosters_inplace
-        cwtools_read_rosters_inplace.argtypes = ()
-
     def process_game_csv(self, game_ptr, roster_visitor=None, roster_home=None):
         cwevent_process_game = self.libchadwick.cwevent_process_game
         cwevent_process_game.argtypes = (
-            POINTER(CWLeague),
+            POINTER(CWGame),
             POINTER(CWRoster),
-            c_char_p,
+            POINTER(CWRoster),
         )
         cwevent_process_game.restype = None
-        league = pointer(CWLeague())
-        roster = pointer(CWRoster())
 
         if not roster_home:
             roster_home = pointer(CWRoster())
+        if not roster_visitor:
+            roster_visitor = pointer(CWRoster())
 
         cwevent_process_game(game_ptr, roster_visitor, roster_home)
-
 
     def process_game(self, game_ptr, roster_visitor=None, roster_home=None):
         cwevent_process_game_record = self.libchadwick.cwevent_process_game_record

--- a/pychadwick/chadwick.py
+++ b/pychadwick/chadwick.py
@@ -117,6 +117,7 @@ class Chadwick:
         cw_game_read = self.libchadwick.cw_game_read
         cw_game_read.restype = POINTER(CWGame)
         cw_game_read.argtypes = (ctypes.c_void_p,)
+
         cw_file_find_first_game = self.libchadwick.cw_file_find_first_game
         cw_file_find_first_game.restype = ctypes.c_int
         cw_file_find_first_game.argtypes = (ctypes.c_void_p,)
@@ -176,12 +177,17 @@ class Chadwick:
 
         event_str = create_string_buffer(b" ", 4096)
         while gameiter.contents.event:
+            print("PYTHON: about to process")
             cwevent_process_game_record(
                 gameiter, roster_visitor, roster_home, event_str
             )
+            print("PYTHON: about to gameiter")
+            print(gameiter.contents.game.contents.game_id)
             self.cw_gameiter_next(gameiter)
+            print("PYTHON: about to dictitize")
             if event_str.value:
                 yield self.dicticize_event_string(event_str.value)
+
 
     def cw_gameiter_create(self, game_ptr):
         func = self.libchadwick.cw_gameiter_create

--- a/pychadwick/libutils/__init__.py
+++ b/pychadwick/libutils/__init__.py
@@ -1,2 +1,3 @@
 from .cwlib import _ChadwickLibrary
+
 ChadwickLibrary = _ChadwickLibrary()

--- a/pychadwick/libutils/cwlib.py
+++ b/pychadwick/libutils/cwlib.py
@@ -4,7 +4,10 @@ import pathlib
 
 class _ChadwickLibrary:
     library_path = (
-        pathlib.Path(__file__).absolute().parent.parent / "lib" / "cwevent" / "libcwevent.so"
+        pathlib.Path(__file__).absolute().parent.parent
+        / "lib"
+        / "cwevent"
+        / "libcwevent.so"
     )
 
     def __init__(self):
@@ -15,4 +18,3 @@ class _ChadwickLibrary:
         if self._dll is None:
             self._dll = ctypes.cdll.LoadLibrary(self.library_path)
         return self._dll
-

--- a/scripts/pych.py
+++ b/scripts/pych.py
@@ -8,18 +8,16 @@ from ctypes import (
     create_string_buffer,
 )
 
-from pychadwick import CWGame
-from pychadwick import CWRoster
-from pychadwick import CWLeague
+from pychadwick.chadwick import Chadwick
+from pychadwick.game import CWGame
+from pychadwick.roster import CWRoster
+from pychadwick.league import CWLeague
 
 
 def read_rosters():
-    lib_path = (
-        "/home/bdilday/.venvs/pychadwick/lib/python3.7/"
-        "site-packages/pychadwick-0.1.0-py3.7-linux-x86_64.egg/"
-        "pychadwick/build/cwevent/libcwevent.so"
-    )
-    dll = ctypes.cdll.LoadLibrary(lib_path)
+    chadwick = Chadwick()
+    dll = chadwick.libchadwick
+
     filename = b"/home/bdilday/github/chadwickbureau/retrosheet/event/regular/TEAM1961"
     f = dll.cw_league_read_file
     f.argtypes = (POINTER(CWLeague), c_char_p)
@@ -42,12 +40,9 @@ def read_rosters():
 
 
 def make_game():
-    lib_path = (
-        "/home/bdilday/.venvs/pychadwick/lib/python3.7/"
-        "site-packages/pychadwick-0.1.0-py3.7-linux-x86_64.egg/"
-        "pychadwick/build/cwevent/libcwevent.so"
-    )
-    dll = ctypes.cdll.LoadLibrary(lib_path)
+    chadwick = Chadwick()
+    dll = chadwick.libchadwick
+
 
     cw_game_create = dll.cw_game_create
     cw_game_create.restype = POINTER(CWGame)
@@ -58,8 +53,8 @@ def make_game():
 
 
 def main():
-    #    p = read_rosters()
-    p = make_game()
+    p = read_rosters()
+    #p = make_game()
     print(p)
 
 

--- a/src/pychadwicklib/cwlib/book.c
+++ b/src/pychadwicklib/cwlib/book.c
@@ -155,6 +155,27 @@ cw_scorebook_remove_game(CWScorebook *scorebook, char *game_id)
 }
 
 static int
+cw_scorebook_strip_comments(FILE *file)
+{
+  while (1) {
+    char buf[256], *tok, *com;
+    if (fgets(buf, 256, file) == NULL) {
+      return 0;
+    }
+
+    tok = cw_strtok(buf);
+    com = cw_strtok(NULL);
+
+    if (tok && !strcmp(tok, "com") && com) {
+    // strip it b moving the FILE pointer past it
+    }
+    else {
+      return 1;
+    }
+  }
+}
+
+static int
 cw_scorebook_read_comments(CWScorebook *scorebook, FILE *file)
 {
   while (1) {

--- a/src/pychadwicklib/cwlib/game.c
+++ b/src/pychadwicklib/cwlib/game.c
@@ -717,27 +717,22 @@ cw_game_read(FILE *file)
   }
 
   tok = cw_strtok(buf);
-  printf("found token %s\n", tok);
 
   if (tok && !strcmp(tok, "id"))
   {
-    printf("*************** searching for game id\n");
 
     char *game_id = cw_strtok(NULL);
     if (game_id)
     {
-      printf("*************** found game_id %s\n", game_id);
       game = cw_game_create(game_id);
     }
     else
     {
-      printf("************** game id is false\n");
       return NULL;
     }
   }
   else
   {
-    printf("*********** token is false\n");
     return NULL;
   }
 
@@ -748,14 +743,12 @@ cw_game_read(FILE *file)
     {
       if (feof(file))
       {
-      printf("breaking because eof\n");
         break;
       }
       else
       {
         if (game)
         {
-        printf("cleaning and freeing game\n");
           cw_game_cleanup(game);
           free(game);
         }
@@ -764,12 +757,10 @@ cw_game_read(FILE *file)
     }
     if (feof(file))
     {
-      printf("breaking because eof2 \n");
       break;
     }
 
     tok = cw_strtok(buf);
-    printf("found INNER token %s\n", tok);
 
     if (!tok || !strcmp(tok, "id"))
     {
@@ -863,7 +854,6 @@ cw_game_read(FILE *file)
     }
     else if (!strcmp(tok, "sub"))
     {
-      printf("found sub!\n");
       char *player_id, *name, *team, *slot, *pos;
       player_id = cw_strtok(NULL);
       name = cw_strtok(NULL);
@@ -879,16 +869,11 @@ cw_game_read(FILE *file)
     }
     else if (!strcmp(tok, "com"))
     {
-      printf("found com!\n");
       char *comment;
-      printf("allocate com\n");
       comment = cw_strtok(NULL);
-      printf("read com\n");
       if (comment)
       {
-        printf("inside com\n");
         cw_game_comment_append(game, comment);
-        printf("appended com\n");
       }
     }
     else if (!strcmp(tok, "data"))

--- a/src/pychadwicklib/cwlib/game.c
+++ b/src/pychadwicklib/cwlib/game.c
@@ -36,7 +36,8 @@
 
 int cw_data_get_item_int(CWData *data, unsigned int index)
 {
-  if (index >= data->num_data) {
+  if (index >= data->num_data)
+  {
     return -1;
   }
   return cw_atoi(data->data[index]);
@@ -44,9 +45,9 @@ int cw_data_get_item_int(CWData *data, unsigned int index)
 
 CWGame *cw_game_create(char *game_id)
 {
-  CWGame *game = (CWGame *) malloc(sizeof(CWGame));
+  CWGame *game = (CWGame *)malloc(sizeof(CWGame));
 
-  game->game_id = (char *) malloc(sizeof(char) * (strlen(game_id) + 1));
+  game->game_id = (char *)malloc(sizeof(char) * (strlen(game_id) + 1));
   strcpy(game->game_id, game_id);
   game->version = NULL;
   game->first_info = NULL;
@@ -77,7 +78,8 @@ CWGame *cw_game_create(char *game_id)
 static void cw_game_cleanup_tags(CWGame *game)
 {
   CWInfo *info = game->first_info;
-  while (info != NULL) {
+  while (info != NULL)
+  {
     CWInfo *next_info = info->next;
     free(info->label);
     free(info->data);
@@ -96,7 +98,8 @@ static void cw_game_cleanup_starters(CWGame *game)
 {
   CWAppearance *starter = game->first_starter;
 
-  while (starter != NULL) {
+  while (starter != NULL)
+  {
     CWAppearance *next_starter = starter->next;
     free(starter->player_id);
     free(starter->name);
@@ -115,15 +118,18 @@ static void cw_game_cleanup_starters(CWGame *game)
  */
 static void cw_game_cleanup_events(CWGame *game, CWEvent *event)
 {
-  if (event->prev != NULL) {
+  if (event->prev != NULL)
+  {
     event->prev->next = NULL;
   }
-  else {
+  else
+  {
     game->first_event = NULL;
   }
   game->last_event = event->prev;
 
-  while (event != NULL) {
+  while (event != NULL)
+  {
     CWEvent *next_event = event->next;
     CWAppearance *sub = event->first_sub;
     CWComment *comment = event->first_comment;
@@ -131,20 +137,24 @@ static void cw_game_cleanup_events(CWGame *game, CWEvent *event)
     free(event->count);
     free(event->pitches);
     free(event->event_text);
-    if (event->pitcher_hand_id) {
+    if (event->pitcher_hand_id)
+    {
       free(event->pitcher_hand_id);
     }
-    if (event->itb_runner_id) {
+    if (event->itb_runner_id)
+    {
       free(event->itb_runner_id);
     }
-    while (sub != NULL) {
+    while (sub != NULL)
+    {
       CWAppearance *next_sub = sub->next;
       free(sub->player_id);
       free(sub->name);
       free(sub);
       sub = next_sub;
     }
-    while (comment != NULL) {
+    while (comment != NULL)
+    {
       CWComment *next_comment = comment->next;
       free(comment->text);
       free(comment);
@@ -161,11 +171,13 @@ static void cw_game_cleanup_events(CWGame *game, CWEvent *event)
 static void cw_game_cleanup_data(CWGame *game)
 {
   CWData *data = game->first_data;
-  while (data != NULL) {
+  while (data != NULL)
+  {
     int i;
     CWData *next_data = data->next;
 
-    for (i = 0; i < data->num_data; free(data->data[i++]));
+    for (i = 0; i < data->num_data; free(data->data[i++]))
+      ;
     free(data->data);
     data = next_data;
   }
@@ -180,11 +192,13 @@ static void cw_game_cleanup_data(CWGame *game)
 static void cw_game_cleanup_stat(CWGame *game)
 {
   CWData *data = game->first_stat;
-  while (data != NULL) {
+  while (data != NULL)
+  {
     int i;
     CWData *next_data = data->next;
 
-    for (i = 0; i < data->num_data; free(data->data[i++]));
+    for (i = 0; i < data->num_data; free(data->data[i++]))
+      ;
     free(data->data);
     data = next_data;
   }
@@ -193,18 +207,19 @@ static void cw_game_cleanup_stat(CWGame *game)
   game->last_stat = NULL;
 }
 
-
 /*
  * Private auxiliary function to cleanup memory from evdata list
  */
 static void cw_game_cleanup_evdata(CWGame *game)
 {
   CWData *data = game->first_evdata;
-  while (data != NULL) {
+  while (data != NULL)
+  {
     int i;
     CWData *next_data = data->next;
 
-    for (i = 0; i < data->num_data; free(data->data[i++]));
+    for (i = 0; i < data->num_data; free(data->data[i++]))
+      ;
     free(data->data);
     data = next_data;
   }
@@ -213,18 +228,19 @@ static void cw_game_cleanup_evdata(CWGame *game)
   game->last_evdata = NULL;
 }
 
-
 /*
  * Private auxiliary function to cleanup memory from data list
  */
 static void cw_game_cleanup_line(CWGame *game)
 {
   CWData *data = game->first_line;
-  while (data != NULL) {
+  while (data != NULL)
+  {
     int i;
     CWData *next_data = data->next;
 
-    for (i = 0; i < data->num_data; free(data->data[i++]));
+    for (i = 0; i < data->num_data; free(data->data[i++]))
+      ;
     free(data->data);
     data = next_data;
   }
@@ -237,7 +253,8 @@ void cw_game_cleanup(CWGame *game)
 {
   cw_game_cleanup_tags(game);
   cw_game_cleanup_starters(game);
-  if (game->first_event != NULL) {
+  if (game->first_event != NULL)
+  {
     cw_game_cleanup_events(game, game->first_event);
     game->first_event = NULL;
   }
@@ -245,7 +262,7 @@ void cw_game_cleanup(CWGame *game)
   cw_game_cleanup_stat(game);
   cw_game_cleanup_line(game);
   cw_game_cleanup_evdata(game);
-   
+
   free(game->version);
   game->version = NULL;
   free(game->game_id);
@@ -254,43 +271,46 @@ void cw_game_cleanup(CWGame *game)
 
 void cw_game_set_version(CWGame *game, char *version)
 {
-  game->version = (char *) malloc(sizeof(char) * (strlen(version) + 1));
+  game->version = (char *)malloc(sizeof(char) * (strlen(version) + 1));
   strcpy(game->version, version);
 }
 
-
 void cw_game_info_append(CWGame *game, char *label, char *data)
 {
-  CWInfo *info = (CWInfo *) malloc(sizeof(CWInfo));
-  info->label = (char *) malloc(sizeof(char) * (strlen(label) + 1));
+  CWInfo *info = (CWInfo *)malloc(sizeof(CWInfo));
+  info->label = (char *)malloc(sizeof(char) * (strlen(label) + 1));
   strcpy(info->label, label);
-  info->data = (char *) malloc(sizeof(char) * (strlen(data) + 1));
+  info->data = (char *)malloc(sizeof(char) * (strlen(data) + 1));
   strcpy(info->data, data);
   info->prev = game->last_info;
   info->next = NULL;
 
-  if (game->first_info == NULL) {
+  if (game->first_info == NULL)
+  {
     game->first_info = info;
   }
-  else {
+  else
+  {
     game->last_info->next = info;
   }
   game->last_info = info;
 }
 
-void
-cw_game_info_set(CWGame *game, char *label, char *data)
+void cw_game_info_set(CWGame *game, char *label, char *data)
 {
   CWInfo *info = game->first_info;
 
-  while (info != NULL) {
-    if (!strcmp(info->label, label)) {
+  while (info != NULL)
+  {
+    if (!strcmp(info->label, label))
+    {
       free(info->data);
-      info->data = (char *) malloc(sizeof(char) * (strlen(data) + 1));
+      info->data = (char *)malloc(sizeof(char) * (strlen(data) + 1));
       strcpy(info->data, data);
       return;
     }
-    else {
+    else
+    {
       info = info->next;
     }
   }
@@ -310,8 +330,10 @@ cw_game_info_set(CWGame *game, char *label, char *data)
 char *cw_game_info_lookup(CWGame *game, char *label)
 {
   CWInfo *info;
-  for (info = game->last_info; info; info = info->prev) {
-    if (!strcmp(info->label, label)) {
+  for (info = game->last_info; info; info = info->prev)
+  {
+    if (!strcmp(info->label, label))
+    {
       return info->data;
     }
   }
@@ -320,12 +342,12 @@ char *cw_game_info_lookup(CWGame *game, char *label)
 }
 
 void cw_game_starter_append(CWGame *game, char *player_id, char *name,
-			    int team, int slot, int pos)
+                            int team, int slot, int pos)
 {
-  CWAppearance *starter = (CWAppearance *) malloc(sizeof(CWAppearance));
-  starter->player_id = (char *) malloc(sizeof(char) * (strlen(player_id) + 1));
+  CWAppearance *starter = (CWAppearance *)malloc(sizeof(CWAppearance));
+  starter->player_id = (char *)malloc(sizeof(char) * (strlen(player_id) + 1));
   strcpy(starter->player_id, player_id);
-  starter->name = (char *) malloc(sizeof(char) * (strlen(name) + 1));
+  starter->name = (char *)malloc(sizeof(char) * (strlen(name) + 1));
   strcpy(starter->name, name);
   starter->team = team;
   starter->slot = slot;
@@ -333,10 +355,12 @@ void cw_game_starter_append(CWGame *game, char *player_id, char *name,
   starter->prev = game->last_starter;
   starter->next = NULL;
 
-  if (game->first_starter == NULL) {
+  if (game->first_starter == NULL)
+  {
     game->first_starter = starter;
   }
-  else {
+  else
+  {
     game->last_starter->next = starter;
   }
   game->last_starter = starter;
@@ -346,8 +370,10 @@ CWAppearance *
 cw_game_starter_find(CWGame *game, int team, int slot)
 {
   CWAppearance *starter = game->first_starter;
-  while (starter != NULL) {
-    if (starter->team == team && starter->slot == slot) {
+  while (starter != NULL)
+  {
+    if (starter->team == team && starter->slot == slot)
+    {
       return starter;
     }
     starter = starter->next;
@@ -360,8 +386,10 @@ CWAppearance *
 cw_game_starter_find_by_position(CWGame *game, int team, int pos)
 {
   CWAppearance *starter = game->first_starter;
-  while (starter != NULL) {
-    if (starter->team == team && starter->pos == pos) {
+  while (starter != NULL)
+  {
+    if (starter->team == team && starter->pos == pos)
+    {
       return starter;
     }
     starter = starter->next;
@@ -371,19 +399,19 @@ cw_game_starter_find_by_position(CWGame *game, int team, int pos)
 }
 
 void cw_game_event_append(CWGame *game, int inning, int batting_team,
-			  char *batter, char *count, char *pitches,
-			  char *event_text)
+                          char *batter, char *count, char *pitches,
+                          char *event_text)
 {
-  CWEvent *event = (CWEvent *) malloc(sizeof(CWEvent));
+  CWEvent *event = (CWEvent *)malloc(sizeof(CWEvent));
   event->inning = inning;
   event->batting_team = batting_team;
-  event->batter = (char *) malloc(sizeof(char) * (strlen(batter) + 1));
+  event->batter = (char *)malloc(sizeof(char) * (strlen(batter) + 1));
   strcpy(event->batter, batter);
-  event->count = (char *) malloc(sizeof(char) * (strlen(count) + 1));
+  event->count = (char *)malloc(sizeof(char) * (strlen(count) + 1));
   strcpy(event->count, count);
-  event->pitches = (char *) malloc(sizeof(char) * (strlen(pitches) + 1));
+  event->pitches = (char *)malloc(sizeof(char) * (strlen(pitches) + 1));
   strcpy(event->pitches, pitches);
-  event->event_text = (char *) malloc(sizeof(char) * (strlen(event_text) + 1));
+  event->event_text = (char *)malloc(sizeof(char) * (strlen(event_text) + 1));
   strcpy(event->event_text, event_text);
   event->batter_hand = ' ';
   event->pitcher_hand = ' ';
@@ -399,10 +427,12 @@ void cw_game_event_append(CWGame *game, int inning, int batting_team,
   event->first_comment = NULL;
   event->last_comment = NULL;
 
-  if (game->first_event == NULL) {
+  if (game->first_event == NULL)
+  {
     game->first_event = event;
   }
-  else {
+  else
+  {
     game->last_event->next = event;
   }
   game->last_event = event;
@@ -414,22 +444,24 @@ void cw_game_truncate(CWGame *game, CWEvent *event)
 }
 
 void cw_game_substitute_append(CWGame *game, char *player_id, char *name,
-			       int team, int slot, int pos)
+                               int team, int slot, int pos)
 {
-  CWAppearance *sub = (CWAppearance *) malloc(sizeof(CWAppearance));
-  sub->player_id = (char *) malloc(sizeof(char) * (strlen(player_id) + 1));
+  CWAppearance *sub = (CWAppearance *)malloc(sizeof(CWAppearance));
+  sub->player_id = (char *)malloc(sizeof(char) * (strlen(player_id) + 1));
   strcpy(sub->player_id, player_id);
-  sub->name = (char *) malloc(sizeof(char) * (strlen(name) + 1));
+  sub->name = (char *)malloc(sizeof(char) * (strlen(name) + 1));
   strcpy(sub->name, name);
   sub->team = team;
   sub->slot = slot;
   sub->pos = pos;
   sub->prev = game->last_event->last_sub;
   sub->next = NULL;
-  if (game->last_event->last_sub) {
+  if (game->last_event->last_sub)
+  {
     game->last_event->last_sub->next = sub;
   }
-  else {
+  else
+  {
     game->last_event->first_sub = sub;
   }
   game->last_event->last_sub = sub;
@@ -438,21 +470,24 @@ void cw_game_substitute_append(CWGame *game, char *player_id, char *name,
 void cw_game_data_append(CWGame *game, int num_data, char **data)
 {
   int i;
-  CWData *d = (CWData *) malloc(sizeof(CWData));
+  CWData *d = (CWData *)malloc(sizeof(CWData));
 
   d->num_data = num_data;
-  d->data = (char **) malloc(sizeof(char *) * num_data);
+  d->data = (char **)malloc(sizeof(char *) * num_data);
   d->next = NULL;
-  
-  for (i = 0; i < num_data; i++) {
-    d->data[i] = (char *) malloc(sizeof(char) * (strlen(data[i]) + 1));
+
+  for (i = 0; i < num_data; i++)
+  {
+    d->data[i] = (char *)malloc(sizeof(char) * (strlen(data[i]) + 1));
     strcpy(d->data[i], data[i]);
   }
 
-  if (game->first_data) {
+  if (game->first_data)
+  {
     game->last_data->next = d;
   }
-  else {
+  else
+  {
     game->first_data = d;
   }
   d->prev = game->last_data;
@@ -465,12 +500,14 @@ void cw_game_data_set_er(CWGame *game, char *playerID, int er)
   char buffer[10];
   CWData *data = game->first_data;
 
-  while (data != NULL) {
+  while (data != NULL)
+  {
     if (data->num_data >= 3 &&
-	!strcmp(data->data[0], "er") &&
-	!strcmp(data->data[1], playerID)) {
+        !strcmp(data->data[0], "er") &&
+        !strcmp(data->data[1], playerID))
+    {
       free(data->data[2]);
-      data->data[2] = (char *) malloc(10 * sizeof(char));
+      data->data[2] = (char *)malloc(10 * sizeof(char));
       sprintf(data->data[2], "%d", er);
       return;
     }
@@ -484,25 +521,27 @@ void cw_game_data_set_er(CWGame *game, char *playerID, int er)
   cw_game_data_append(game, 3, foo);
 }
 
-
 void cw_game_stat_append(CWGame *game, int num_data, char **data)
 {
   int i;
-  CWData *d = (CWData *) malloc(sizeof(CWData));
+  CWData *d = (CWData *)malloc(sizeof(CWData));
 
   d->num_data = num_data;
-  d->data = (char **) malloc(sizeof(char *) * num_data);
+  d->data = (char **)malloc(sizeof(char *) * num_data);
   d->next = NULL;
-  
-  for (i = 0; i < num_data; i++) {
-    d->data[i] = (char *) malloc(sizeof(char) * (strlen(data[i]) + 1));
+
+  for (i = 0; i < num_data; i++)
+  {
+    d->data[i] = (char *)malloc(sizeof(char) * (strlen(data[i]) + 1));
     strcpy(d->data[i], data[i]);
   }
 
-  if (game->first_stat) {
+  if (game->first_stat)
+  {
     game->last_stat->next = d;
   }
-  else {
+  else
+  {
     game->first_stat = d;
   }
   d->prev = game->last_stat;
@@ -512,21 +551,24 @@ void cw_game_stat_append(CWGame *game, int num_data, char **data)
 void cw_game_evdata_append(CWGame *game, int num_data, char **data)
 {
   int i;
-  CWData *d = (CWData *) malloc(sizeof(CWData));
+  CWData *d = (CWData *)malloc(sizeof(CWData));
 
   d->num_data = num_data;
-  d->data = (char **) malloc(sizeof(char *) * num_data);
+  d->data = (char **)malloc(sizeof(char *) * num_data);
   d->next = NULL;
-  
-  for (i = 0; i < num_data; i++) {
-    d->data[i] = (char *) malloc(sizeof(char) * (strlen(data[i]) + 1));
+
+  for (i = 0; i < num_data; i++)
+  {
+    d->data[i] = (char *)malloc(sizeof(char) * (strlen(data[i]) + 1));
     strcpy(d->data[i], data[i]);
   }
 
-  if (game->first_evdata) {
+  if (game->first_evdata)
+  {
     game->last_evdata->next = d;
   }
-  else {
+  else
+  {
     game->first_evdata = d;
   }
   d->prev = game->last_evdata;
@@ -536,21 +578,24 @@ void cw_game_evdata_append(CWGame *game, int num_data, char **data)
 void cw_game_line_append(CWGame *game, int num_data, char **data)
 {
   int i;
-  CWData *d = (CWData *) malloc(sizeof(CWData));
+  CWData *d = (CWData *)malloc(sizeof(CWData));
 
   d->num_data = num_data;
-  d->data = (char **) malloc(sizeof(char *) * num_data);
+  d->data = (char **)malloc(sizeof(char *) * num_data);
   d->next = NULL;
-  
-  for (i = 0; i < num_data; i++) {
-    d->data[i] = (char *) malloc(sizeof(char) * (strlen(data[i]) + 1));
+
+  for (i = 0; i < num_data; i++)
+  {
+    d->data[i] = (char *)malloc(sizeof(char) * (strlen(data[i]) + 1));
     strcpy(d->data[i], data[i]);
   }
 
-  if (game->first_line) {
+  if (game->first_line)
+  {
     game->last_line->next = d;
   }
-  else {
+  else
+  {
     game->first_line = d;
   }
   d->prev = game->last_line;
@@ -559,83 +604,99 @@ void cw_game_line_append(CWGame *game, int num_data, char **data)
 
 void cw_game_comment_append(CWGame *game, char *text)
 {
-  CWComment *comment = (CWComment *) malloc(sizeof(CWComment));
-  comment->text = (char *) malloc(sizeof(char) * (strlen(text) + 1));
+  CWComment *comment = (CWComment *)malloc(sizeof(CWComment));
+  comment->text = (char *)malloc(sizeof(char) * (strlen(text) + 1));
   strcpy(comment->text, text);
   comment->next = NULL;
 
-  if (game->first_event == NULL) {
+  if (game->first_event == NULL)
+  {
     comment->prev = game->last_comment;
-    if (game->last_comment) {
+    if (game->last_comment)
+    {
       game->last_comment->next = comment;
     }
-    else {
+    else
+    {
       game->first_comment = comment;
     }
     game->last_comment = comment;
   }
-  else {
+  else
+  {
     comment->prev = game->last_event->last_comment;
-    if (game->last_event->last_comment) {
+    if (game->last_event->last_comment)
+    {
       game->last_event->last_comment->next = comment;
     }
-    else {
+    else
+    {
       game->last_event->first_comment = comment;
     }
     game->last_event->last_comment = comment;
   }
 }
 
-void 
-cw_game_replace_player(CWGame *game, char *key_old, char *key_new) 
+void cw_game_replace_player(CWGame *game, char *key_old, char *key_new)
 {
   CWAppearance *sub;
   CWData *data;
   CWEvent *event;
 
-  for (sub = game->first_starter; sub != NULL; sub = sub->next) {
-    if (!strcmp(sub->player_id, key_old)) {
+  for (sub = game->first_starter; sub != NULL; sub = sub->next)
+  {
+    if (!strcmp(sub->player_id, key_old))
+    {
       free(sub->player_id);
-      sub->player_id = (char *) malloc(sizeof(char) * (strlen(key_new)+1));
+      sub->player_id = (char *)malloc(sizeof(char) * (strlen(key_new) + 1));
       strcpy(sub->player_id, key_new);
     }
   }
 
-  for (event = game->first_event; event != NULL; event = event->next) {
-    if (!strcmp(event->batter, key_old)) {
+  for (event = game->first_event; event != NULL; event = event->next)
+  {
+    if (!strcmp(event->batter, key_old))
+    {
       free(event->batter);
-      event->batter = (char *) malloc(sizeof(char) * (strlen(key_new)+1));
+      event->batter = (char *)malloc(sizeof(char) * (strlen(key_new) + 1));
       strcpy(event->batter, key_new);
     }
 
-    for (sub = event->first_sub; sub != NULL; sub = sub->next) {
-      if (!strcmp(sub->player_id, key_old)) {
-	free(sub->player_id);
-	sub->player_id = (char *) malloc(sizeof(char) * (strlen(key_new)+1));
-	strcpy(sub->player_id, key_new);
+    for (sub = event->first_sub; sub != NULL; sub = sub->next)
+    {
+      if (!strcmp(sub->player_id, key_old))
+      {
+        free(sub->player_id);
+        sub->player_id = (char *)malloc(sizeof(char) * (strlen(key_new) + 1));
+        strcpy(sub->player_id, key_new);
       }
     }
   }
 
-  for (data = game->first_data; data != NULL; data = data->next) {
+  for (data = game->first_data; data != NULL; data = data->next)
+  {
     if (data->num_data >= 3 && !strcmp(data->data[0], "er") &&
-	!strcmp(data->data[1], key_old)) {
+        !strcmp(data->data[1], key_old))
+    {
       free(data->data[1]);
-      data->data[1] = (char *) malloc(sizeof(char) * (strlen(key_new)+1));
+      data->data[1] = (char *)malloc(sizeof(char) * (strlen(key_new) + 1));
       strcpy(data->data[1], key_new);
     }
   }
 
   if (cw_game_info_lookup(game, "wp") != NULL &&
-      !strcmp(cw_game_info_lookup(game, "wp"), key_old)) {
+      !strcmp(cw_game_info_lookup(game, "wp"), key_old))
+  {
     cw_game_info_set(game, "wp", key_new);
   }
   if (cw_game_info_lookup(game, "lp") != NULL &&
-      !strcmp(cw_game_info_lookup(game, "lp"), key_old)) {
+      !strcmp(cw_game_info_lookup(game, "lp"), key_old))
+  {
     cw_game_info_set(game, "lp", key_new);
   }
   if (cw_game_info_lookup(game, "save") != NULL &&
-      !strcmp(cw_game_info_lookup(game, "save"), key_old)) {
+      !strcmp(cw_game_info_lookup(game, "save"), key_old))
+  {
     cw_game_info_set(game, "save", key_new);
   }
 }
@@ -650,75 +711,107 @@ cw_game_read(FILE *file)
   int ladjAlign = 0, ladjSlot = 0, itbBase = 0;
   CWGame *game;
 
-  if (fgets(buf, 1024, file) == NULL) {
-    return NULL;
-  }
-  tok = cw_strtok(buf);
-  if (tok && !strcmp(tok, "id")) {
-    char *game_id = cw_strtok(NULL);
-    if (game_id) {
-      game = cw_game_create(game_id);
-    }
-    else {
-      return NULL;
-    }
-  }
-  else {
+  if (fgets(buf, 1024, file) == NULL)
+  {
     return NULL;
   }
 
-  while (!feof(file)) {
+  tok = cw_strtok(buf);
+  printf("found token %s\n", tok);
+
+  if (tok && !strcmp(tok, "id"))
+  {
+    printf("*************** searching for game id\n");
+
+    char *game_id = cw_strtok(NULL);
+    if (game_id)
+    {
+      printf("*************** found game_id %s\n", game_id);
+      game = cw_game_create(game_id);
+    }
+    else
+    {
+      printf("************** game id is false\n");
+      return NULL;
+    }
+  }
+  else
+  {
+    printf("*********** token is false\n");
+    return NULL;
+  }
+
+  while (!feof(file))
+  {
     fgetpos(file, &filepos);
-    if (fgets(buf, 1024, file) == NULL) {
-      if (feof(file)) {
-	break;
+    if (fgets(buf, 1024, file) == NULL)
+    {
+      if (feof(file))
+      {
+      printf("breaking because eof\n");
+        break;
       }
-      else {
-	if (game) {
-	  cw_game_cleanup(game);
-	  free(game);
-	}
-	return NULL;
+      else
+      {
+        if (game)
+        {
+        printf("cleaning and freeing game\n");
+          cw_game_cleanup(game);
+          free(game);
+        }
+        return NULL;
       }
     }
-    if (feof(file)) {
+    if (feof(file))
+    {
+      printf("breaking because eof2 \n");
       break;
     }
 
     tok = cw_strtok(buf);
-    if (!tok || !strcmp(tok, "id")) {
+    printf("found INNER token %s\n", tok);
+
+    if (!tok || !strcmp(tok, "id"))
+    {
       fsetpos(file, &filepos);
       break;
     }
-    else if (!strcmp(tok, "version")) {
+    else if (!strcmp(tok, "version"))
+    {
       char *version;
       version = cw_strtok(NULL);
-      if (version) {
-	cw_game_set_version(game, version);
+      if (version)
+      {
+        cw_game_set_version(game, version);
       }
     }
-    else if (!strcmp(tok, "info")) {
+    else if (!strcmp(tok, "info"))
+    {
       char *field, *value;
       field = cw_strtok(NULL);
       value = cw_strtok(NULL);
-      if (field) {
-	cw_game_info_append(game, field, (value) ? value : "");
+      if (field)
+      {
+        cw_game_info_append(game, field, (value) ? value : "");
       }
     }
-    else if (!strcmp(tok, "start")) {
+    else if (!strcmp(tok, "start"))
+    {
       char *player_id, *name, *team, *slot, *pos;
       player_id = cw_strtok(NULL);
       name = cw_strtok(NULL);
       team = cw_strtok(NULL);
       slot = cw_strtok(NULL);
       pos = cw_strtok(NULL);
-      if (player_id && name && team && slot && pos) {
-	cw_game_starter_append(game, player_id, name,
-			       cw_atoi(team), cw_atoi(slot), 
-			       cw_atoi(pos));
+      if (player_id && name && team && slot && pos)
+      {
+        cw_game_starter_append(game, player_id, name,
+                               cw_atoi(team), cw_atoi(slot),
+                               cw_atoi(pos));
       }
-    } 
-    else if (!strcmp(tok, "play")) {
+    }
+    else if (!strcmp(tok, "play"))
+    {
       char *inning, *batting_team, *batter, *count, *pitches, *play;
       inning = cw_strtok(NULL);
       batting_team = cw_strtok(NULL);
@@ -726,148 +819,184 @@ cw_game_read(FILE *file)
       count = cw_strtok(NULL);
       pitches = cw_strtok(NULL);
       play = cw_strtok(NULL);
-      if (inning && batting_team && batter && count && pitches && play) {
-	cw_game_event_append(game, cw_atoi(inning), cw_atoi(batting_team),
-			     batter, count, pitches, play);
+      if (inning && batting_team && batter && count && pitches && play)
+      {
+        cw_game_event_append(game, cw_atoi(inning), cw_atoi(batting_team),
+                             batter, count, pitches, play);
       }
-      if (batHand != ' ' && !strcmp(batHandBatter, batter)) {
-	game->last_event->batter_hand = batHand;
+      if (batHand != ' ' && !strcmp(batHandBatter, batter))
+      {
+        game->last_event->batter_hand = batHand;
       }
-      else {
-	/* Once batter changes, clear this out */
-	batHand = ' ';
-	strcpy(batHandBatter, "");
-      }
-
-      if (pitHand != ' ') {
-	game->last_event->pitcher_hand = pitHand;
-	game->last_event->pitcher_hand_id = (char *) malloc(strlen(pitHandPitcher)+1);
-	strcpy(game->last_event->pitcher_hand_id, pitHandPitcher);
-	pitHand = ' ';
-	strcpy(pitHandPitcher, "");
+      else
+      {
+        /* Once batter changes, clear this out */
+        batHand = ' ';
+        strcpy(batHandBatter, "");
       }
 
-      if (ladjSlot != 0) {
-	game->last_event->ladj_align = ladjAlign;
-	game->last_event->ladj_slot = ladjSlot;
-	ladjAlign = 0;
-	ladjSlot = 0;
+      if (pitHand != ' ')
+      {
+        game->last_event->pitcher_hand = pitHand;
+        game->last_event->pitcher_hand_id = (char *)malloc(strlen(pitHandPitcher) + 1);
+        strcpy(game->last_event->pitcher_hand_id, pitHandPitcher);
+        pitHand = ' ';
+        strcpy(pitHandPitcher, "");
       }
 
-      if (itbBase != 0) {
-	game->last_event->itb_base = itbBase;
-	game->last_event->itb_runner_id = (char *) malloc(strlen(itbRunner)+1);
-	strcpy(game->last_event->itb_runner_id, itbRunner);
-	itbBase = 0;
-	strcpy(itbRunner, "");
+      if (ladjSlot != 0)
+      {
+        game->last_event->ladj_align = ladjAlign;
+        game->last_event->ladj_slot = ladjSlot;
+        ladjAlign = 0;
+        ladjSlot = 0;
+      }
+
+      if (itbBase != 0)
+      {
+        game->last_event->itb_base = itbBase;
+        game->last_event->itb_runner_id = (char *)malloc(strlen(itbRunner) + 1);
+        strcpy(game->last_event->itb_runner_id, itbRunner);
+        itbBase = 0;
+        strcpy(itbRunner, "");
       }
     }
-    else if (!strcmp(tok, "sub")) {
+    else if (!strcmp(tok, "sub"))
+    {
+      printf("found sub!\n");
       char *player_id, *name, *team, *slot, *pos;
       player_id = cw_strtok(NULL);
       name = cw_strtok(NULL);
       team = cw_strtok(NULL);
       slot = cw_strtok(NULL);
       pos = cw_strtok(NULL);
-      if (player_id && name && team && slot && pos) {
-	cw_game_substitute_append(game, player_id, name,
-				  cw_atoi(team), cw_atoi(slot), 
-				  cw_atoi(pos));
+      if (player_id && name && team && slot && pos)
+      {
+        cw_game_substitute_append(game, player_id, name,
+                                  cw_atoi(team), cw_atoi(slot),
+                                  cw_atoi(pos));
       }
     }
-    else if (!strcmp(tok, "com")) {
+    else if (!strcmp(tok, "com"))
+    {
+      printf("found com!\n");
       char *comment;
+      printf("allocate com\n");
       comment = cw_strtok(NULL);
-      if (comment) {
-	cw_game_comment_append(game, comment);
+      printf("read com\n");
+      if (comment)
+      {
+        printf("inside com\n");
+        cw_game_comment_append(game, comment);
+        printf("appended com\n");
       }
     }
-    else if (!strcmp(tok, "data")) {
+    else if (!strcmp(tok, "data"))
+    {
       char *data[256];
       int i;
 
-      for (i = 0; i < 256; i++) {
-	data[i] = cw_strtok(NULL);
-	if (!data[i]) {
-	  cw_game_data_append(game, i, data);
-	  break;
-	}
+      for (i = 0; i < 256; i++)
+      {
+        data[i] = cw_strtok(NULL);
+        if (!data[i])
+        {
+          cw_game_data_append(game, i, data);
+          break;
+        }
       }
     }
-    else if (!strcmp(tok, "stat")) {
+    else if (!strcmp(tok, "stat"))
+    {
       char *data[256];
       int i;
 
-      for (i = 0; i < 256; i++) {
-	data[i] = cw_strtok(NULL);
-	if (!data[i] || isspace(data[i][0])) {
-	  cw_game_stat_append(game, i, data);
-	  break;
-	}
+      for (i = 0; i < 256; i++)
+      {
+        data[i] = cw_strtok(NULL);
+        if (!data[i] || isspace(data[i][0]))
+        {
+          cw_game_stat_append(game, i, data);
+          break;
+        }
       }
     }
-    else if (!strcmp(tok, "event")) {
+    else if (!strcmp(tok, "event"))
+    {
       char *data[256];
       int i;
 
-      for (i = 0; i < 256; i++) {
-	data[i] = cw_strtok(NULL);
-	if (!data[i] || isspace(data[i][0])) {
-	  cw_game_evdata_append(game, i, data);
-	  break;
-	}
+      for (i = 0; i < 256; i++)
+      {
+        data[i] = cw_strtok(NULL);
+        if (!data[i] || isspace(data[i][0]))
+        {
+          cw_game_evdata_append(game, i, data);
+          break;
+        }
       }
     }
-    else if (!strcmp(tok, "line")) {
+    else if (!strcmp(tok, "line"))
+    {
       char *data[256];
       int i;
 
-      for (i = 0; i < 256; i++) {
-	data[i] = cw_strtok(NULL);
-	if (!data[i] || data[i][0] == '\0') {
-	  cw_game_line_append(game, i, data);
-	  break;
-	}
+      for (i = 0; i < 256; i++)
+      {
+        data[i] = cw_strtok(NULL);
+        if (!data[i] || data[i][0] == '\0')
+        {
+          cw_game_line_append(game, i, data);
+          break;
+        }
       }
     }
-    else if (!strcmp(tok, "badj")) {
+    else if (!strcmp(tok, "badj"))
+    {
       char *batter, *bats;
       batter = cw_strtok(NULL);
       bats = cw_strtok(NULL);
-      if (batter && bats) {
-	strncpy(batHandBatter, batter, 255);
-	batHand = bats[0];
+      if (batter && bats)
+      {
+        strncpy(batHandBatter, batter, 255);
+        batHand = bats[0];
       }
     }
-    else if (!strcmp(tok, "padj")) {
+    else if (!strcmp(tok, "padj"))
+    {
       char *pitcher, *throws;
       pitcher = cw_strtok(NULL);
       throws = cw_strtok(NULL);
-      if (pitcher && throws) {
-	strncpy(pitHandPitcher, pitcher, 255);
-	pitHand = throws[0];
+      if (pitcher && throws)
+      {
+        strncpy(pitHandPitcher, pitcher, 255);
+        pitHand = throws[0];
       }
     }
-    else if (!strcmp(tok, "ladj")) {
+    else if (!strcmp(tok, "ladj"))
+    {
       char *align, *slot;
       align = cw_strtok(NULL);
       slot = cw_strtok(NULL);
-      if (align && slot) {
-	ladjAlign = cw_atoi(align);
-	ladjSlot = cw_atoi(slot);
-      }      
+      if (align && slot)
+      {
+        ladjAlign = cw_atoi(align);
+        ladjSlot = cw_atoi(slot);
+      }
     }
-    else if (!strcmp(tok, "cw:itb")) {
+    else if (!strcmp(tok, "cw:itb"))
+    {
       /* Chadwick extension: international tiebreaker */
       /* Format: cw:itb,runner-id,base */
       char *runner, *base;
       runner = cw_strtok(NULL);
       base = cw_strtok(NULL);
-      if (runner && base) {
-	strncpy(itbRunner, runner, 255);
-	itbBase = cw_atoi(base);
+      if (runner && base)
+      {
+        strncpy(itbRunner, runner, 255);
+        itbBase = cw_atoi(base);
       }
-    }      
+    }
   }
 
   return game;
@@ -881,25 +1010,28 @@ cw_game_write_header(CWGame *game, FILE *file)
   fprintf(file, "id,%s\n", game->game_id);
   fprintf(file, "version,%s\n", game->version);
 
-  while (info != NULL) {
+  while (info != NULL)
+  {
     /*
      * Use explicit quotes around the data if either a comma appears
      * in the data, or to be output-compatible with existing tools 
      */
     if (strstr(info->data, ",") ||
-	!strcmp(info->label, "inputprogvers") ||
-	!strcmp(info->label, "umphome") ||
-	!strcmp(info->label, "ump1b") ||
-	!strcmp(info->label, "ump2b") ||
-	!strcmp(info->label, "ump3b") ||
-	!strcmp(info->label, "umplf") ||
-	!strcmp(info->label, "umprf") ||
-	!strcmp(info->label, "scorer") ||
-	!strcmp(info->label, "translator") ||
-	!strcmp(info->label, "inputter")) {
+        !strcmp(info->label, "inputprogvers") ||
+        !strcmp(info->label, "umphome") ||
+        !strcmp(info->label, "ump1b") ||
+        !strcmp(info->label, "ump2b") ||
+        !strcmp(info->label, "ump3b") ||
+        !strcmp(info->label, "umplf") ||
+        !strcmp(info->label, "umprf") ||
+        !strcmp(info->label, "scorer") ||
+        !strcmp(info->label, "translator") ||
+        !strcmp(info->label, "inputter"))
+    {
       fprintf(file, "info,%s,\"%s\"\n", info->label, info->data);
     }
-    else {
+    else
+    {
       fprintf(file, "info,%s,%s\n", info->label, info->data);
     }
     info = info->next;
@@ -911,10 +1043,11 @@ cw_game_write_starters(CWGame *game, FILE *file)
 {
   CWAppearance *starter = game->first_starter;
 
-  while (starter != NULL) {
+  while (starter != NULL)
+  {
     fprintf(file, "start,%s,\"%s\",%d,%d,%d\n",
-	    starter->player_id, starter->name,
-	    starter->team, starter->slot, starter->pos);
+            starter->player_id, starter->name,
+            starter->team, starter->slot, starter->pos);
     starter = starter->next;
   }
 }
@@ -924,7 +1057,8 @@ cw_game_write_comments(CWGame *game, FILE *file)
 {
   CWComment *comment = game->first_comment;
 
-  while (comment != NULL) {
+  while (comment != NULL)
+  {
     fprintf(file, "com,\"%s\"\n", comment->text);
     comment = comment->next;
   }
@@ -935,37 +1069,46 @@ cw_game_write_events(CWGame *game, FILE *file)
 {
   CWEvent *event = game->first_event;
 
-  while (event != NULL) {
-    if (event->batter_hand != ' ') {
+  while (event != NULL)
+  {
+    if (event->batter_hand != ' ')
+    {
       fprintf(file, "badj,%s,%c\n", event->batter, event->batter_hand);
     }
-    if (event->pitcher_hand != ' ') {
+    if (event->pitcher_hand != ' ')
+    {
       fprintf(file, "padj,%s,%c\n", event->pitcher_hand_id, event->pitcher_hand);
     }
-    if (event->ladj_slot != 0) {
+    if (event->ladj_slot != 0)
+    {
       fprintf(file, "ladj,%d,%d\n", event->ladj_align, event->ladj_slot);
     }
-    if (event->itb_base != 0) {
+    if (event->itb_base != 0)
+    {
       fprintf(file, "cw:itb,%s,%d\n", event->itb_runner_id, event->itb_base);
-    }      
+    }
     fprintf(file, "play,%d,%d,%s,%s,%s,%s\n",
-	    event->inning, event->batting_team,
-	    event->batter, event->count, event->pitches,
-	    event->event_text);
-    if (event->first_sub != NULL) {
+            event->inning, event->batting_team,
+            event->batter, event->count, event->pitches,
+            event->event_text);
+    if (event->first_sub != NULL)
+    {
       CWAppearance *sub = event->first_sub;
-      while (sub != NULL) {
-	fprintf(file, "sub,%s,\"%s\",%d,%d,%d\n",
-		sub->player_id, sub->name, 
-		sub->team, sub->slot, sub->pos);
-	sub = sub->next;
+      while (sub != NULL)
+      {
+        fprintf(file, "sub,%s,\"%s\",%d,%d,%d\n",
+                sub->player_id, sub->name,
+                sub->team, sub->slot, sub->pos);
+        sub = sub->next;
       }
     }
-    if (event->first_comment != NULL) {
+    if (event->first_comment != NULL)
+    {
       CWComment *comment = event->first_comment;
-      while (comment != NULL) {
-	fprintf(file, "com,\"%s\"\n", comment->text);
-	comment = comment->next;
+      while (comment != NULL)
+      {
+        fprintf(file, "com,\"%s\"\n", comment->text);
+        comment = comment->next;
       }
     }
     event = event->next;
@@ -976,12 +1119,14 @@ static void
 cw_game_write_stat(CWGame *game, FILE *file)
 {
   CWData *data = game->first_stat;
-  
-  while (data != NULL) {
+
+  while (data != NULL)
+  {
     int i;
 
     fprintf(file, "stat");
-    for (i = 0; i < data->num_data; i++) {
+    for (i = 0; i < data->num_data; i++)
+    {
       fprintf(file, ",%s", data->data[i]);
     }
     fprintf(file, "\n");
@@ -993,12 +1138,14 @@ static void
 cw_game_write_line(CWGame *game, FILE *file)
 {
   CWData *data = game->first_line;
-  
-  while (data != NULL) {
+
+  while (data != NULL)
+  {
     int i;
 
     fprintf(file, "line");
-    for (i = 0; i < data->num_data; i++) {
+    for (i = 0; i < data->num_data; i++)
+    {
       fprintf(file, ",%s", data->data[i]);
     }
     fprintf(file, "\n");
@@ -1010,12 +1157,14 @@ static void
 cw_game_write_data(CWGame *game, FILE *file)
 {
   CWData *data = game->first_data;
-  
-  while (data != NULL) {
+
+  while (data != NULL)
+  {
     int i;
 
     fprintf(file, "data");
-    for (i = 0; i < data->num_data; i++) {
+    for (i = 0; i < data->num_data; i++)
+    {
       fprintf(file, ",%s", data->data[i]);
     }
     fprintf(file, "\n");
@@ -1023,8 +1172,7 @@ cw_game_write_data(CWGame *game, FILE *file)
   }
 }
 
-void
-cw_game_write(CWGame *game, FILE *file)
+void cw_game_write(CWGame *game, FILE *file)
 {
   cw_game_write_header(game, file);
   cw_game_write_starters(game, file);
@@ -1035,23 +1183,20 @@ cw_game_write(CWGame *game, FILE *file)
   cw_game_write_data(game, file);
 }
 
-void 
-cw_event_comment_append(CWEvent *event, char *text)
+void cw_event_comment_append(CWEvent *event, char *text)
 {
-  CWComment *comment = (CWComment *) malloc(sizeof(CWComment));
-  comment->text = (char *) malloc(sizeof(char) * (strlen(text) + 1));
+  CWComment *comment = (CWComment *)malloc(sizeof(CWComment));
+  comment->text = (char *)malloc(sizeof(char) * (strlen(text) + 1));
   strcpy(comment->text, text);
   comment->next = NULL;
   comment->prev = event->last_comment;
-  if (event->last_comment) {
+  if (event->last_comment)
+  {
     event->last_comment->next = comment;
   }
-  else {
+  else
+  {
     event->first_comment = comment;
   }
   event->last_comment = comment;
 }
-
-
-
-

--- a/src/pychadwicklib/cwlib/gameiter.c
+++ b/src/pychadwicklib/cwlib/gameiter.c
@@ -845,22 +845,38 @@ cw_gameiter_process_comments(CWGameIterator *gameiter)
 void 
 cw_gameiter_next(CWGameIterator *gameiter)
 {
+ // printf("event_text %s\n", gameiter->event->event_text);
+
+    printf("%i\n", gameiter);
+
+    // if event is null, just return.
+    // this happens when NP is the last event, ie a rain cancellation
+    if (!gameiter->event) {
+    return;
+    }
+    printf("%i\n", gameiter->event);
+
+
   if (strcmp(gameiter->event->event_text, "NP")) {
     cw_gamestate_update(gameiter->state, 
 			gameiter->event->batter, gameiter->event_data);
 
   }
 
+    printf("about to process comments.....................\n");
   cw_gameiter_process_comments(gameiter);
   cw_gameiter_process_subs(gameiter);
+ printf("done  process comments.....................\n");
 
   /* Now, move on to the next event, and parse it.
    * There are a few entries in the CWEventData that are context-dependent,
    * in the sense that they cannot fully be inferred from the 
    * event text alone.  The remaining code handles those cases.
    */
-  gameiter->event = gameiter->event->next;
+   printf("first event %s\n", gameiter->event->event_text);
+    gameiter->event = gameiter->event->next;
 
+    printf("here1\n");
   if (gameiter->event != NULL &&
       (gameiter->state->inning != gameiter->event->inning || 
        gameiter->state->batting_team != gameiter->event->batting_team)) {
@@ -881,9 +897,11 @@ cw_gameiter_next(CWGameIterator *gameiter)
     cw_gamestate_change_sides(gameiter->state, gameiter->event);
   }
 
+    printf("here2\n");
   if (gameiter->event && gameiter->event->ladj_slot != 0) {
     gameiter->state->next_batter[gameiter->state->batting_team] = gameiter->event->ladj_slot;
   }
+      printf("here3\n");
   if (gameiter->event && gameiter->event->itb_base != 0) {
     strcpy(gameiter->state->runners[gameiter->event->itb_base],
 	   gameiter->event->itb_runner_id);
@@ -893,6 +911,7 @@ cw_gameiter_next(CWGameIterator *gameiter)
 	    gameiter->state->fielders[2][1-gameiter->state->batting_team], 49);
     gameiter->state->num_itb_runners[gameiter->state->batting_team]++;
   }
+      printf("here4\n");
   if (gameiter->event && strcmp(gameiter->event->event_text, "NP")) {
     int i;
     gameiter->state->batter_hand = gameiter->event->batter_hand;
@@ -927,6 +946,7 @@ cw_gameiter_next(CWGameIterator *gameiter)
     }
 
   }
+      printf("here5\n");
 }
 
 /* Compute the eventual "fate" of the runner on 'base' */

--- a/src/pychadwicklib/cwlib/gameiter.c
+++ b/src/pychadwicklib/cwlib/gameiter.c
@@ -845,16 +845,13 @@ cw_gameiter_process_comments(CWGameIterator *gameiter)
 void 
 cw_gameiter_next(CWGameIterator *gameiter)
 {
- // printf("event_text %s\n", gameiter->event->event_text);
-
-    printf("%i\n", gameiter);
 
     // if event is null, just return.
     // this happens when NP is the last event, ie a rain cancellation
     if (!gameiter->event) {
     return;
     }
-    printf("%i\n", gameiter->event);
+    //printf("%i\n", gameiter->event);
 
 
   if (strcmp(gameiter->event->event_text, "NP")) {
@@ -863,20 +860,20 @@ cw_gameiter_next(CWGameIterator *gameiter)
 
   }
 
-    printf("about to process comments.....................\n");
+  //  printf("about to process comments.....................\n");
   cw_gameiter_process_comments(gameiter);
   cw_gameiter_process_subs(gameiter);
- printf("done  process comments.....................\n");
+// printf("done  process comments.....................\n");
 
   /* Now, move on to the next event, and parse it.
    * There are a few entries in the CWEventData that are context-dependent,
    * in the sense that they cannot fully be inferred from the 
    * event text alone.  The remaining code handles those cases.
    */
-   printf("first event %s\n", gameiter->event->event_text);
+ //  printf("first event %s\n", gameiter->event->event_text);
     gameiter->event = gameiter->event->next;
 
-    printf("here1\n");
+//    printf("here1\n");
   if (gameiter->event != NULL &&
       (gameiter->state->inning != gameiter->event->inning || 
        gameiter->state->batting_team != gameiter->event->batting_team)) {
@@ -897,11 +894,9 @@ cw_gameiter_next(CWGameIterator *gameiter)
     cw_gamestate_change_sides(gameiter->state, gameiter->event);
   }
 
-    printf("here2\n");
   if (gameiter->event && gameiter->event->ladj_slot != 0) {
     gameiter->state->next_batter[gameiter->state->batting_team] = gameiter->event->ladj_slot;
   }
-      printf("here3\n");
   if (gameiter->event && gameiter->event->itb_base != 0) {
     strcpy(gameiter->state->runners[gameiter->event->itb_base],
 	   gameiter->event->itb_runner_id);
@@ -911,7 +906,6 @@ cw_gameiter_next(CWGameIterator *gameiter)
 	    gameiter->state->fielders[2][1-gameiter->state->batting_team], 49);
     gameiter->state->num_itb_runners[gameiter->state->batting_team]++;
   }
-      printf("here4\n");
   if (gameiter->event && strcmp(gameiter->event->event_text, "NP")) {
     int i;
     gameiter->state->batter_hand = gameiter->event->batter_hand;
@@ -946,7 +940,6 @@ cw_gameiter_next(CWGameIterator *gameiter)
     }
 
   }
-      printf("here5\n");
 }
 
 /* Compute the eventual "fate" of the runner on 'base' */

--- a/src/pychadwicklib/cwlib/league.c
+++ b/src/pychadwicklib/cwlib/league.c
@@ -85,6 +85,24 @@ cw_league_roster_find(CWLeague *league, char *team)
   return roster;
 }
 
+void
+cw_league_init_read_file(CWLeague *league, char *filename) {
+
+  FILE *file;
+
+  league = (CWLeague *) malloc(sizeof(CWLeague));
+  league->first_roster = NULL;
+  league->last_roster = NULL;
+
+  printf("opening file %s\n", filename);
+  file = fopen(filename, "r");
+  if (!file) {
+    printf("Cannot open file %s\n", filename);
+  }
+  cw_league_read(league, file);
+}
+
+
 /* reads league from a file. the league pointer must be initialized with a call
    to cw_league_create first. 
 */
@@ -119,7 +137,7 @@ cw_league_read(CWLeague *rosterList, FILE *file)
       continue;
     }
 
-    cw_league_roster_append(rosterList, 
+    cw_league_roster_append(rosterList,
 			    cw_roster_create(team_id, 0, league,
 					     city, nickname));
   }

--- a/src/pychadwicklib/cwtools/cwevent.c
+++ b/src/pychadwicklib/cwtools/cwevent.c
@@ -1911,15 +1911,12 @@ void cwevent_process_game_record(
   int i, comma;
 
   CWEvent *event = gameiter->event;
-  printf("found event %s\n", event->event_text);
+//  printf("found event %s\n", event->event_text);
 
   if (!strcmp(event->event_text, "NP"))
   {
-    printf("advancing gamiter\n");
     cw_gameiter_next(gameiter);
-    printf("done advancing gameiter\n");
     strcpy(output_line, "");
-    printf("carry on\n");
     return;
   }
 
@@ -1958,8 +1955,8 @@ void cwevent_process_game_record(
     }
   };
 
-  printf("%s", output_line);
-  printf("\n");
+//  printf("%s", output_line);
+//  printf("\n");
   
 }
 
@@ -1973,8 +1970,8 @@ cwevent_process_game(CWGame *game, CWRoster *visitors, CWRoster *home)
 
   while (gameiter->event != NULL) {
     cwevent_process_game_record(gameiter, visitors, home, output_line);
-//    printf("%s", output_line);
-//    printf("\n");
+    printf("%s", output_line);
+    printf("\n");
     cw_gameiter_next(gameiter);
   }
 

--- a/src/pychadwicklib/cwtools/cwevent.c
+++ b/src/pychadwicklib/cwtools/cwevent.c
@@ -1911,12 +1911,15 @@ void cwevent_process_game_record(
   int i, comma;
 
   CWEvent *event = gameiter->event;
+  printf("found event %s\n", event->event_text);
 
   if (!strcmp(event->event_text, "NP"))
   {
+    printf("advancing gamiter\n");
     cw_gameiter_next(gameiter);
+    printf("done advancing gameiter\n");
     strcpy(output_line, "");
-
+    printf("carry on\n");
     return;
   }
 
@@ -1936,7 +1939,7 @@ void cwevent_process_game_record(
         comma = 1;
       }
       buf += (*cwevent_field_data[i].f)(buf, gameiter, visitors, home);
-    }
+      }
   }
 
   for (i = 0; i <= max_ext_field; i++)
@@ -1955,8 +1958,8 @@ void cwevent_process_game_record(
     }
   };
 
-//  printf("%s", output_line);
-//  printf("\n");
+  printf("%s", output_line);
+  printf("\n");
   
 }
 

--- a/src/pychadwicklib/cwtools/cwtools.c
+++ b/src/pychadwicklib/cwtools/cwtools.c
@@ -103,6 +103,45 @@ void set_game_id(char *s) {
 }
 
 void
+cwtools_read_rosters_inplace(CWLeague *league, CWRoster *roster, char *filename)
+{
+  FILE *teamfile;
+
+  teamfile = fopen(filename, "r");
+
+  if (teamfile == NULL) {
+    /* Also try lowercase version */
+    sprintf(filename, "team%s", year);
+
+    teamfile = fopen(filename, "r");
+
+    if (teamfile == NULL) {
+      fprintf(stderr, "Can't find teamfile (%s)\n", filename);
+      exit(1);
+    }
+  }
+
+  cw_league_read(league, teamfile);
+  fclose(teamfile);
+
+  for (roster = league->first_roster; roster; roster = roster->next) {
+    FILE *file;
+
+    sprintf(filename, "%s%s.ROS", roster->team_id, year);
+    file = fopen(filename, "r");
+
+    if (file == NULL) {
+      /* bevent silently ignores missing roster files and generates
+       * question marks for bats/throws for unknown players */
+      continue;
+    }
+
+    cw_roster_read(roster, file);
+    fclose(file);
+  }
+}
+
+void
 cwtools_read_rosters(CWLeague *league)
 {
   char filename[256];

--- a/tests/pychadwick/test_pychadwick.py
+++ b/tests/pychadwick/test_pychadwick.py
@@ -17,12 +17,24 @@ def test_chadwick():
 def test_load_games():
     chadwick = Chadwick()
 
-    for team_event in ["1982OAK", "1991BAL"]:
+    for team_event in ["1982OAK.EVA", "1991BAL.EVA", "1954PHI.EVN"]:
         event_path = get_event_path(
-            f"https://raw.githubusercontent.com/chadwickbureau/retrosheet/master/event/regular/{team_event}.EVA"
+            f"https://raw.githubusercontent.com/chadwickbureau/retrosheet/master/event/regular/{team_event}"
         )
         games = chadwick.games(event_path)
         game = next(games)
         game_it = chadwick.process_game(game)
         record = next(game_it)
         assert "GAME_ID" in record.keys()
+
+
+def test_load_games_to_df():
+    chadwick = Chadwick()
+
+    for team_event in ["1982OAK.EVA", "1991BAL.EVA", "1954PHI.EVN"]:
+        event_path = get_event_path(
+            f"https://raw.githubusercontent.com/chadwickbureau/retrosheet/master/event/regular/{team_event}"
+        )
+        games = chadwick.games(event_path)
+        dfs = [chadwick.game_to_dataframe(game) for game in games]
+

--- a/tests/pychadwick/test_pychadwick.py
+++ b/tests/pychadwick/test_pychadwick.py
@@ -61,5 +61,6 @@ def test_game_to_csv(chadwick, team_events):
 
 
 def test_init_read_league(chadwick):
-    file_name = b"/tmp/retrosheet-master/event/regular/TEAM1982"
-    league = chadwick.cw_league_read(file_name)
+    url = "https://raw.githubusercontent.com/chadwickbureau/retrosheet/master/event/regular/TEAM1982"
+    file_path = get_event_path(url)
+    _ = chadwick.cw_league_read(bytes(file_path, "utf8"))

--- a/tests/pychadwick/test_pychadwick.py
+++ b/tests/pychadwick/test_pychadwick.py
@@ -4,14 +4,17 @@ from pychadwick.chadwick import Chadwick
 import tempfile
 import requests
 
+
 @pytest.fixture
 def chadwick():
     return Chadwick()
+
 
 @pytest.fixture
 def team_events():
     team_events = ["1982OAK.EVA", "1991BAL.EVA", "1954PHI.EVN"]
     return team_events
+
 
 def get_event_path(url):
     file_path = tempfile.gettempdir() + "/tmp.EVA"
@@ -45,6 +48,17 @@ def test_load_games_to_df(chadwick, team_events):
         )
         games = chadwick.games(event_path)
         dfs = [chadwick.game_to_dataframe(game) for game in games]
+
+
+def test_game_to_csv(chadwick, team_events):
+
+    for team_event in team_events:
+        event_path = get_event_path(
+            f"https://raw.githubusercontent.com/chadwickbureau/retrosheet/master/event/regular/{team_event}"
+        )
+        games = chadwick.games(event_path)
+        dfs = [chadwick.process_game_csv(game) for game in games]
+
 
 def test_init_read_league(chadwick):
     file_name = b"/tmp/retrosheet-master/event/regular/TEAM1982"

--- a/tests/pychadwick/test_pychadwick.py
+++ b/tests/pychadwick/test_pychadwick.py
@@ -1,7 +1,17 @@
+import pytest
+
 from pychadwick.chadwick import Chadwick
 import tempfile
 import requests
 
+@pytest.fixture
+def chadwick():
+    return Chadwick()
+
+@pytest.fixture
+def team_events():
+    team_events = ["1982OAK.EVA", "1991BAL.EVA", "1954PHI.EVN"]
+    return team_events
 
 def get_event_path(url):
     file_path = tempfile.gettempdir() + "/tmp.EVA"
@@ -14,10 +24,9 @@ def test_chadwick():
     _ = Chadwick()
 
 
-def test_load_games():
-    chadwick = Chadwick()
+def test_load_games(chadwick, team_events):
 
-    for team_event in ["1982OAK.EVA", "1991BAL.EVA", "1954PHI.EVN"]:
+    for team_event in team_events:
         event_path = get_event_path(
             f"https://raw.githubusercontent.com/chadwickbureau/retrosheet/master/event/regular/{team_event}"
         )
@@ -28,13 +37,15 @@ def test_load_games():
         assert "GAME_ID" in record.keys()
 
 
-def test_load_games_to_df():
-    chadwick = Chadwick()
+def test_load_games_to_df(chadwick, team_events):
 
-    for team_event in ["1982OAK.EVA", "1991BAL.EVA", "1954PHI.EVN"]:
+    for team_event in team_events:
         event_path = get_event_path(
             f"https://raw.githubusercontent.com/chadwickbureau/retrosheet/master/event/regular/{team_event}"
         )
         games = chadwick.games(event_path)
         dfs = [chadwick.game_to_dataframe(game) for game in games]
 
+def test_init_read_league(chadwick):
+    file_name = b"/tmp/retrosheet-master/event/regular/TEAM1982"
+    league = chadwick.cw_league_read(file_name)


### PR DESCRIPTION
Fixes and issue where a segmentation fault was being triggered when a NP was the last event of a game, example in a game called due to rain. There is still some work to do to interface with leagues and rosters and to double check consistency with the chadwick CLI tool, but this is in an ok state for now.