### PR TITLE
fixes sub event processing bug 🎉

### DIFF
--- a/pychadwick/chadwick.py
+++ b/pychadwick/chadwick.py
@@ -210,6 +210,10 @@ class Chadwick:
 
         event_str = create_string_buffer(b" ", 4096)
         while gameiter.contents.event:
+            if gameiter.contents.event.contents.event_text == b"NP":
+                logging.debug("event text == NP")
+                self.cw_gameiter_next(gameiter)
+                continue
             cwevent_process_game_record(
                 gameiter, roster_visitor, roster_home, event_str
             )

--- a/scripts/c_chadwick_regression_test.py
+++ b/scripts/c_chadwick_regression_test.py
@@ -35,7 +35,7 @@ def check_equality(pychadwick_df, cchadwick_df):
         df1 = pychadwick_df.query('GAME_ID == "{}"'.format(game_id))
         df2 = cchadwick_df.query('GAME_ID == "{}"'.format(game_id))
         try:
-            assert_frame_equal(df1, df2)
+            assert_frame_equal(df1, df2, check_dtype=False)
         except AssertionError:
             print(f"error: game {game_id} is not identical")
             num_errors += 1

--- a/scripts/c_chadwick_regression_test.py
+++ b/scripts/c_chadwick_regression_test.py
@@ -22,7 +22,7 @@ def get_pychadwick_df():
         "retrosheet-master",
         "event",
         "regular",
-        "1982OAK.EVA",
+        f"{args.season}{args.team}.EV{args.league}",
     )
     pychadwick_df = chadwick.event_file_to_dataframe(event_file)
     return pychadwick_df
@@ -49,11 +49,19 @@ def main():
     num_errors = check_equality(pychadwick_df, cchadwick_df)
     sys.exit(int(bool(num_errors)))
 
+import argparse
+def _parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--season", required=False, default=1982, type=int)
+    parser.add_argument("--team", required=False, default="OAK")
+    parser.add_argument("--league", required=False, default="A")
+    return parser.parse_args(sys.argv[1:])
 
 if __name__ == "__main__":
-    LOCAL_EVENT_FILE = "/tmp/1982OAK_c_chadwick.csv"
-    if not os.path.exists(LOCAL_EVENT_FILE):
-        subprocess.run([CHADWICK_SCRIPT])
+    args = _parse_args()
+    LOCAL_EVENT_FILE = f"/tmp/{args.season}{args.team}_c_chadwick.csv"
+    #if not os.path.exists(LOCAL_EVENT_FILE):
+    subprocess.run([CHADWICK_SCRIPT, str(args.season), args.team, args.league])
 
     chadwick = Chadwick()
     for h in chadwick.all_headers:

--- a/scripts/run_cwevent.sh
+++ b/scripts/run_cwevent.sh
@@ -3,11 +3,11 @@
 LAST_PWD=$PWD
 CWEVENT_EXE=$HOME/github/chadwickbureau/chadwick/src/cwtools/cwevent
 FIELDS="0,2,3,4,10,14,34"
-SEASON=1982
-TEAM=OAK
-LEAGUE=A
+SEASON=${1:-"1982"}
+TEAM=${2:-"OAK"}
+LEAGUE=${3:-"A"}
 DATA_ROOT=$HOME/.pybbda/data
-OUTPUT_FILE=/tmp/1982OAK_c_chadwick.csv
+OUTPUT_FILE=/tmp/${SEASON}${TEAM}_c_chadwick.csv
 
 cd $DATA_ROOT/retrosheet/retrosheet-master/event/regular/
 $CWEVENT_EXE -f $FIELDS -n -y $SEASON ${SEASON}${TEAM}.EV${LEAGUE} > $OUTPUT_FILE

--- a/src/pychadwicklib/cwlib/gameiter.c
+++ b/src/pychadwicklib/cwlib/gameiter.c
@@ -849,9 +849,8 @@ cw_gameiter_next(CWGameIterator *gameiter)
     // if event is null, just return.
     // this happens when NP is the last event, ie a rain cancellation
     if (!gameiter->event) {
-    return;
+      return;
     }
-    //printf("%i\n", gameiter->event);
 
 
   if (strcmp(gameiter->event->event_text, "NP")) {
@@ -870,9 +869,9 @@ cw_gameiter_next(CWGameIterator *gameiter)
    * in the sense that they cannot fully be inferred from the 
    * event text alone.  The remaining code handles those cases.
    */
- //  printf("first event %s\n", gameiter->event->event_text);
+   //printf("first event %s\n", gameiter->event->event_text);
     gameiter->event = gameiter->event->next;
-
+   
 //    printf("here1\n");
   if (gameiter->event != NULL &&
       (gameiter->state->inning != gameiter->event->inning || 

--- a/src/pychadwicklib/cwtools/cwevent.c
+++ b/src/pychadwicklib/cwtools/cwevent.c
@@ -1915,7 +1915,8 @@ void cwevent_process_game_record(
 
   if (!strcmp(event->event_text, "NP"))
   {
-    cw_gameiter_next(gameiter);
+    fprintf(stderr, "WARNING: event text in cwevent_process_game_record == NP\n");
+    //cw_gameiter_next(gameiter);
     strcpy(output_line, "");
     return;
   }
@@ -1969,9 +1970,11 @@ cwevent_process_game(CWGame *game, CWRoster *visitors, CWRoster *home)
   CWGameIterator *gameiter = cw_gameiter_create(game);
 
   while (gameiter->event != NULL) {
-    cwevent_process_game_record(gameiter, visitors, home, output_line);
-    printf("%s", output_line);
-    printf("\n");
+    if (strcmp(gameiter->event->event_text, "NP")) {
+      cwevent_process_game_record(gameiter, visitors, home, output_line);
+      printf("%s", output_line);
+      printf("\n");
+    }
     cw_gameiter_next(gameiter);
   }
 


### PR DESCRIPTION
There was a bug where around a `sub` event the `gameiter` was advanced twice, causing the event following the sub to be absent from the processed events. The relevance of the `sub` is that prior to a sub, the event is marked `NP`. The fundamental cause for the following game event to be skipped was that in the orginial c code, the processing happens in the same function as the filtering of `NP`, where in this modified code the processing has been broken out into its own function (`cwevent_process_game_record`). In the c code if the event is an `NP` then the pointer is advanced and the loop is continued without processing the NP event. On the other hand, by putting the processing logic in its own function, it lead to ambiguity about where the filtering of `NP` happens. I originally had it happen in the `cwevent_process_game_record` function, so that that function could be self-contained. Unfortunately the filtering also happened in the loop around the calls to `cwevent_process_game_record`. This PR fixes that faulty logic, such that the filtering of `NP` only happens in the loop. This better matches the original c code. The downside is the loop has to check the `event_text` field and avoid passing it to `cwevent_process_game_record`. 

This fix has been tested with the `c_chadwick_regression_test.py` script using the `1982OAK.EVA` file. This probably closes https://github.com/bdilday/pychadwick/issues/9 but I want to double check on additonal events files to be sure.