### PR TITLE
adds platform check in library load

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,6 @@ clean:
 	python setup.py clean
 
 dist: clean
-	python setup.py bdist_wheel
 	python setup.py sdist
 
 docs: install-dev

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ clean:
 	python setup.py clean
 
 dist: clean
+	python setup.py bdist_wheel
 	python setup.py sdist
 
 docs: install-dev

--- a/pychadwick/__init__.py
+++ b/pychadwick/__init__.py
@@ -2,7 +2,7 @@ from pandas import Int32Dtype
 from pychadwick.libutils import ChadwickLibrary
 
 
-_version = "0.4.0"
+_version = "0.5.0.dev0"
 
 __all__ = ["ChadwickLibrary"]
 

--- a/pychadwick/__init__.py
+++ b/pychadwick/__init__.py
@@ -2,7 +2,7 @@ from pandas import Int32Dtype
 from pychadwick.libutils import ChadwickLibrary
 
 
-_version = "0.5.0.dev0"
+_version = "0.5.0"
 
 __all__ = ["ChadwickLibrary"]
 

--- a/pychadwick/libutils/cwlib.py
+++ b/pychadwick/libutils/cwlib.py
@@ -1,13 +1,14 @@
 import ctypes
 import pathlib
+import sys
 
-
+FILE_EXTENSION = {"darwin": "dylib", "linux": "so", "windows": "dll"}
 class _ChadwickLibrary:
     library_path = (
         pathlib.Path(__file__).absolute().parent.parent
         / "lib"
         / "cwevent"
-        / "libcwevent.so"
+        / f"libcwevent.{FILE_EXTENSION.get(sys.platform)}"
     )
 
     def __init__(self):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.0
+current_version = 0.5.0.dev0
 
 [flake8]
 max-line-length = 90

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.5.0.dev0
+current_version = 0.5.0
 
 [flake8]
 max-line-length = 90

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 setup(
     name="pychadwick",
-    version="0.4.0",
+    version="0.5.0.dev0",
     author="Ben Dilday",
     author_email="ben.dilday.phd@gmail.com",
     description="Python bindings to the Chadwick library",

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 setup(
     name="pychadwick",
-    version="0.5.0.dev0",
+    version="0.5.0",
     author="Ben Dilday",
     author_email="ben.dilday.phd@gmail.com",
     description="Python bindings to the Chadwick library",


### PR DESCRIPTION
Adds platform check before trying to load the chadwick shared library, which determines the extension of the library. Should fix https://github.com/bdilday/pychadwick/issues/25