### PR TITLE
workflows: Fix pythonpackage workflow actions (linting and testing)

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -4,17 +4,34 @@ on: [push]
 
 jobs:
   build:
-
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false # TODO can be re-enabled once new builds are stable
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7]
+        python-version: ["3.9", "3.10", "3.11"]
+        os:
+          - ubuntu-22.04
+        include:
+          # Test older/EoL python versions on ubuntu-20.04
+          # Ubuntu 22.04 comes with OpenSSL 3.0, so only CPython 3.9+ is compatible with it
+          # https://github.com/python/cpython/issues/83001
+          - python-version: "3.6"
+            os: ubuntu-20.04
+          - python-version: "3.7"
+            os: ubuntu-20.04
+          #- python-version: "3.8"
+          #  os: ubuntu-20.04
+        exclude:
+          # FIXME disable versions >=3.8 until builds are fixed for those versions
+          - python-version: "3.9"
+          - python-version: "3.10"
+          - python-version: "3.11"
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-black==19.10b0
+black==22.8.0
 pytest==5.4.3
 flake8==3.8.2
 requests==2.22.0


### PR DESCRIPTION
Thanks for this repo!

I'm opening a separate issue to track an issue running the library on python 3.8+, but the workflow actions are currently not successful for 3.6 and 3.7; this gets the workflow builds back to green for those known working versions.

Fixes:
- ubuntu-latest is now 22.04, which doesn't support python <=3.8. Force those versions to use ubuntu-20.04
- Switch to latest actions/checkout and setup-python versions to get rid of deprecation warnings.
- Add support for building against py 3.8+, but those are disabled for now as those builds are failing.
- Bump black to 22.8 to get rid of compatibility issue with installed version of click  (22.8 is last version to support 3.6 thru 3.11)